### PR TITLE
feat!: refactor dependency injection initializers and update tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,9 @@ class ViewModel {
 
     var provider: (any ServiceProvider)?
 
-    required init(provider: any ServiceProvider) {
+    // Unlike Service, Injectable does not require a init(provider:) initializer.
+    // You are free to initialize self.provider as you like.
+    init(provider: any ServiceProvider) {
         self.provider = provider
     }
 

--- a/Sources/ETBDependencyInjection/DI/Injectable.swift
+++ b/Sources/ETBDependencyInjection/DI/Injectable.swift
@@ -1,14 +1,11 @@
 
 /// A lightweight protocol that marks a type as capable of receiving dependencies from a `ServiceProvider`.
 ///
-/// Conforming types declare a `provider` property and an initializer that accepts a `ServiceProvider`,
-/// enabling a consistent pattern for dependency injection across your codebase.
+/// Conforming types declare a `provider` property. They are free to initialize that property as they want.
 ///
 /// Adoption
 /// - Conform to `Injectable` when your type requires access to services (e.g., networking, storage,
 ///   logging) that are resolved at runtime.
-/// - Prefer initializing instances with `init(provider:)` to ensure they are fully configured with a
-///   valid provider at creation time.
 /// - The `provider` property is optional to support scenarios where an instance may be created without
 ///   an active provider or receives one later (e.g., during testing or delayed composition).
 ///
@@ -17,7 +14,7 @@
 ///   guarantees when storing or using the `provider`.
 ///
 /// Testing
-/// - In tests, pass a mock or test double conforming to `ServiceProvider` via `init(provider:)`.
+/// - In tests, pass a mock or test double directly or via the provider.
 /// - You may also set `provider` to `nil` to validate behavior when dependencies are unavailable.
 ///
 /// See Also
@@ -28,11 +25,7 @@ public protocol Injectable {
     /// 
     /// - Note: This property is optional to allow for scenarios where an instance may be created without
     ///   an active provider or where the provider can be injected later.
-    /// - Important: When implementing `Injectable`, prefer using the `init(provider:)` initializer to
-    ///   ensure the instance is properly configured with a provider at creation time.
-    /// - SeeAlso: `ServiceProvider`, `init(provider:)`
+    /// - SeeAlso: `ServiceProvider`
     var provider: (any ServiceProvider)? { get }
-    
-    init(provider: any ServiceProvider)
     
 }

--- a/Sources/ETBDependencyInjection/DI/Service.swift
+++ b/Sources/ETBDependencyInjection/DI/Service.swift
@@ -14,7 +14,7 @@
 /// Usage:
 /// - Conform your concrete service to `Service`.
 /// - Choose an `Interface` shape that fits your module boundary (protocol, facade struct, or `Self`).
-/// - Implement `init(provider:)` from `Injectable` to receive dependencies.
+/// - Implement `init(provider:)` to receive dependencies.
 /// - Consumers obtain an instance via `Self.initialization(provider:)`, which returns the `Interface`.
 ///
 /// Example:
@@ -23,13 +23,17 @@
 ///     func fetchCurrentUser() async throws -> User
 /// }
 ///
-/// final class UserService: Service {
+/// final class UserService: UserServiceInterface {
 ///     typealias Interface = UserServiceInterface
+///
+///     var provider: (any ServiceProvider)?
+///
+///     required init(provider: any ServiceProvider) {
+///         self.provider = provider
+///     }
 ///
 ///     // Conform to the interface
 ///     func fetchCurrentUser() async throws -> User { /* ... */ }
-///
-///     // Satisfy Injectable protocol ...
 /// }
 ///
 /// // Elsewhere:
@@ -38,7 +42,7 @@
 ///
 /// Notes:
 /// - If you set `Interface == Self`, ensure the concrete type is what you want to expose publicly.
-/// - The default `initialization(provider:)` implementation constructs `Self` via `Injectable` and
+/// - The default `initialization(provider:)` implementation constructs `Self` and
 ///   force-casts to `Interface`. Ensure your `Interface` choice aligns with the concrete instance
 ///   to avoid runtime casting failures.
 public protocol Service: Injectable {
@@ -74,6 +78,8 @@ public protocol Service: Injectable {
     /// Choose an `Interface` shape that best fits your module boundaries and testing strategy.
     associatedtype Interface
     
+    init(provider: any ServiceProvider)
+
     static func initialization(provider: any ServiceProvider) -> Interface
     
 }

--- a/Sources/ETBDependencyInjectionClient/main.swift
+++ b/Sources/ETBDependencyInjectionClient/main.swift
@@ -29,7 +29,7 @@ class ViewModel {
 
     var provider: (any ServiceProvider)?
     
-    public required init(provider: any ServiceProvider) {
+    init(provider: any ServiceProvider) {
         self.provider = provider
     }
     

--- a/Tests/ETBDependencyInjectionTests/Test_InjectionMacro.swift
+++ b/Tests/ETBDependencyInjectionTests/Test_InjectionMacro.swift
@@ -16,7 +16,7 @@ fileprivate let testMacros: [String: Macro.Type] = [
 
 final class Test_InjectionMacro: XCTestCase {
     
-    func testInjectionWithoutInjectableNotService() throws {
+    func testInjectionWithoutInjectableNorService() throws {
         #if canImport(ETBDependencyInjectionMacros)
         assertMacroExpansion(
             """

--- a/Tests/ETBDependencyInjectionTests/Test_ServiceMacro.swift
+++ b/Tests/ETBDependencyInjectionTests/Test_ServiceMacro.swift
@@ -19,74 +19,6 @@ fileprivate let macroSpecs: [String: MacroSpec] = [
 
 final class Test_ServiceMacro: XCTestCase {
     
-    func testConformDirectlyToService() throws {
-        #if canImport(ETBDependencyInjectionMacros)
-        assertMacroExpansion(
-            """
-            @Service(MyServiceImpl.self)
-            class MyServiceImpl: Service {
-            }
-            """,
-            expandedSource: """
-            
-            class MyServiceImpl: Service {
-            
-                typealias Interface = MyServiceImpl
-            }
-            """,
-            macros: testMacros
-        )
-        #else
-        throw XCTSkip("macros are only supported when running tests for the host platform")
-        #endif
-    }
-    
-    func testConformToSubTypeOfService() throws {
-        #if canImport(ETBDependencyInjectionMacros)
-        assertMacroExpansion(
-            """
-            protocol MyService: Service {}
-
-            @Service(MyService.self)
-            class MyServiceImpl: MyService {
-            }
-            """,
-            expandedSource: """
-            protocol MyService: Service {}
-            class MyServiceImpl: MyService {
-            
-                typealias Interface = MyService
-            }
-            """,
-            macros: testMacros
-        )
-        #else
-        throw XCTSkip("macros are only supported when running tests for the host platform")
-        #endif
-    }
-    
-    func testAlreadyConformDirectlyToService() throws {
-        #if canImport(ETBDependencyInjectionMacros)
-        assertMacroExpansion(
-            """
-            @Service(MyServiceImpl.self)
-            class MyServiceImpl: Service {
-                typealias Interface = MyServiceImpl
-            }
-            """,
-            expandedSource: """
-            
-            class MyServiceImpl: Service {
-                typealias Interface = MyServiceImpl
-            }
-            """,
-            macros: testMacros
-        )
-        #else
-        throw XCTSkip("macros are only supported when running tests for the host platform")
-        #endif
-    }
-    
     func testPublicClass() throws {
         #if canImport(ETBDependencyInjectionMacros)
         assertMacroExpansion(
@@ -126,7 +58,28 @@ final class Test_ServiceMacro: XCTestCase {
             extension MyServiceImpl: ETBDependencyInjection.Service {
             }
             """,
-            macroSpecs: macroSpecs
+            macroSpecs: ["Service": MacroSpec(type: ServiceMacro.self, conformances: ["Service"])]
+        )
+        #else
+        throw XCTSkip("macros are only supported when running tests for the host platform")
+        #endif
+    }
+    
+    func testAlreadyConformingToService() throws {
+        #if canImport(ETBDependencyInjectionMacros)
+        assertMacroExpansion(
+            """
+            @Service(MyServiceImpl.self)
+            class MyServiceImpl {
+            }
+            """,
+            expandedSource: """
+            class MyServiceImpl {
+            
+                typealias Interface = MyServiceImpl
+            }
+            """,
+            macroSpecs: ["Service": MacroSpec(type: ServiceMacro.self, conformances: [])]
         )
         #else
         throw XCTSkip("macros are only supported when running tests for the host platform")
@@ -146,11 +99,8 @@ final class Test_ServiceMacro: XCTestCase {
             
                 typealias Interface = MyService
             }
-            
-            extension MyServiceImpl: ETBDependencyInjection.Service {
-            }
             """,
-            macroSpecs: macroSpecs
+            macroSpecs: ["Service": MacroSpec(type: ServiceMacro.self, conformances: [])]
         )
         #else
         throw XCTSkip("macros are only supported when running tests for the host platform")
@@ -170,11 +120,8 @@ final class Test_ServiceMacro: XCTestCase {
             
                 typealias Interface = any MyService
             }
-            
-            extension MyServiceImpl: ETBDependencyInjection.Service {
-            }
             """,
-            macroSpecs: macroSpecs
+            macroSpecs: ["Service": MacroSpec(type: ServiceMacro.self, conformances: [])]
         )
         #else
         throw XCTSkip("macros are only supported when running tests for the host platform")


### PR DESCRIPTION
- remove init(provider:) from Injectable protocol
- add init(provider:) to Service protocol
- eliminate all references to Injectable.init(provider:)
- update tests to reflect protocol changes

BREAKING CHANGE: Injectable no longer defines init(provider:). Implementations must migrate initializer requirements to the Service protocol where applicable.