### PR TITLE
feat(macros): infer public accessor for generated members via DeclMod…

### DIFF
--- a/Sources/ETBDependencyInjectionMacros/ETBDependencyInjectionMacro+Utils.swift
+++ b/Sources/ETBDependencyInjectionMacros/ETBDependencyInjectionMacro+Utils.swift
@@ -1,0 +1,10 @@
+import SwiftSyntax
+
+extension DeclModifierSyntax {
+  var isNeededAccessLevelModifier: Bool {
+    switch self.name.tokenKind {
+    case .keyword(.public): return true
+    default: return false
+    }
+  }
+}

--- a/Sources/ETBDependencyInjectionMacros/ServiceMacro.swift
+++ b/Sources/ETBDependencyInjectionMacros/ServiceMacro.swift
@@ -23,10 +23,6 @@ public struct ServiceMacro: MemberMacro {
             return []
         }
         
-        let isPublic = declaration.modifiers.contains {
-            return DeclModifierSyntax($0)?.name.text == "public"
-        }
-        
         guard let argumentList = LabeledExprListSyntax(node.arguments),
               argumentList.count == 1,
               let firstArg = argumentList.first else {
@@ -74,11 +70,12 @@ public struct ServiceMacro: MemberMacro {
         }
         
         var result: [DeclSyntax] = []
+        let access = declaration.modifiers.first(where: \.isNeededAccessLevelModifier)
         
         if !isTypeAliasAlreadyPresent {
             let syntax: DeclSyntax =
             """
-                \(raw: isPublic ? "public " : "")typealias Interface = \(interfaceType)   
+                \(access)typealias Interface = \(interfaceType)   
             """
             result.append(syntax)
         }
@@ -86,7 +83,7 @@ public struct ServiceMacro: MemberMacro {
         if !isProviderAlreadyPresent {
             let syntax: DeclSyntax =
             """
-                \(raw: isPublic ? "public " : "")var provider: (any ETBDependencyInjection.ServiceProvider)?   
+                \(access)var provider: (any ETBDependencyInjection.ServiceProvider)?   
             """
             result.append(syntax)
         }
@@ -94,7 +91,7 @@ public struct ServiceMacro: MemberMacro {
         if !isInitProviderAlreadyPresent {
             let syntax: DeclSyntax =
             """
-                \(raw: isPublic ? "public " : "")required init(provider: any ETBDependencyInjection.ServiceProvider) {
+                \(access)required init(provider: any ETBDependencyInjection.ServiceProvider) {
                     self.provider = provider
                 }
             """


### PR DESCRIPTION
…ifierSyntax

- add computed property on DeclModifierSyntax to determine if MemberMacro-generated members should be public
- use this property in Service macro to set access level for synthesized members (e.g., provider and init(provider:))
- improves consistency of access control based on original declaration modifiers