### PR TITLE
refactor(service-macro): extract Interface typealias synthesis and si…

### DIFF
--- a/Tests/ETBDependencyInjectionTests/Test_ServiceMacro.swift
+++ b/Tests/ETBDependencyInjectionTests/Test_ServiceMacro.swift
@@ -172,7 +172,7 @@ final class Test_ServiceMacro: XCTestCase {
         #endif
     }
     
-    func testTypealiasAlreadyPresent() throws {
+    func testTypeAliasAlreadyPresent() throws {
         #if canImport(ETBDependencyInjectionMacros)
         assertMacroExpansion(
             """


### PR DESCRIPTION
…mplify expansion

move generation of `typealias Interface = ...` into a dedicated helper method
- streamline Service macro `expansion` by delegating typealias construction to the new helper
- improves readability and maintainability without changing macro behavior